### PR TITLE
Fix: method_missing needs to be a class method

### DIFF
--- a/notification-settings/lib/notification_settings/notification_scopes.rb
+++ b/notification-settings/lib/notification_settings/notification_scopes.rb
@@ -7,11 +7,7 @@ module NotificationSettings
   module NotificationScopes
     extend ActiveSupport::Concern
 
-    included do
-      include NotificationSettings::NotificationScopes::InstanceMethods
-    end
-
-    module InstanceMethods
+    module ClassMethods
       def method_missing(method, *args)
         if method.to_s[/(.+)_category/]
           where(category: $1.singularize.classify)


### PR DESCRIPTION
... in order for dynamic scopes like `Notification.notification_category` to work.

This changes NotificationSettings::NotificationScopes to match
NotificationRenderer::NotificationScopes.
