### PR TITLE
[#34] Document in notification-settings that `rails g notification_handler:install` must be run prior to `rails g notification_settings:install`

### DIFF
--- a/notification-settings/README.md
+++ b/notification-settings/README.md
@@ -49,6 +49,7 @@ gem 'notification-settings', github: 'jonhue/notifications-rails'
 
 Now run the generator:
 
+    $ rails g notification_handler:install
     $ rails g notification_settings:install
 
 To wrap things up, migrate the changes to your database:


### PR DESCRIPTION
Resolves #34
