### PR TITLE
[#15] Fix render_notifications not showing notifications

### DIFF
--- a/notification-renderer/app/helpers/notification_renderer_helper.rb
+++ b/notification-renderer/app/helpers/notification_renderer_helper.rb
@@ -19,7 +19,7 @@ module NotificationRendererHelper
   def render_notifications(notifications, renderer: default_renderer)
     content_tag :div, class: 'notification-renderer notifications' do
       notifications&.map do |notification|
-        render_notification(notification, renderer: renderer)
+        concat render_notification(notification, renderer: renderer)
       end
     end
   end

--- a/notification-renderer/spec/helpers/notification_renderer_helper_spec.rb
+++ b/notification-renderer/spec/helpers/notification_renderer_helper_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../rails_helper' 
+
+RSpec.describe NotificationRendererHelper, :type => :helper do
+  describe 'render_notifications' do
+    it 'renders notifications using default renderer' do
+        notification1 = create_title_and_content_notification('title1', 'content1')
+        notification2 = create_title_and_content_notification('title2', 'content2')
+
+        rendered = helper.render_notifications([notification1, notification2])
+
+        # see notification render format at ../support/rails_app/app/views/notifications/title_and_content/_index.html.erb
+        expect(rendered).to eq('<div class="notification-renderer notifications"><div>title1: content1</div><div>title2: content2</div></div>')
+    end
+  end
+end
+
+def create_title_and_content_notification(title, content)
+  Notification.create(type: 'title_and_content', metadata: {title: title, content: content})
+end

--- a/notification-renderer/spec/support/rails_app/app/views/notifications/title_and_content/_index.html.erb
+++ b/notification-renderer/spec/support/rails_app/app/views/notifications/title_and_content/_index.html.erb
@@ -1,0 +1,1 @@
+<div><%= notification.metadata[:title] %>: <%= notification.metadata[:content] %></div>


### PR DESCRIPTION
I implemented this proposal: https://github.com/jonhue/notifications-rails/issues/15#issuecomment-586898114

Basically add `concat` before calling `render_notification`:

```
notifications&.map do |notification|
    concat render_notification(notification, renderer: renderer)
end
```


Resolves #15
