### PR TITLE
Supports ActiveRecord >= 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+*.sqlite*

--- a/notification-handler/lib/notification_handler/notification_lib.rb
+++ b/notification-handler/lib/notification_handler/notification_lib.rb
@@ -11,7 +11,11 @@ module NotificationHandler
 
       after_commit :cache
 
-      serialize :metadata, Hash
+      if ActiveRecord.gem_version >= Gem::Version.new('7.0.0')
+        serialize :metadata, type: Hash, coder: YAML
+      else
+        serialize :metadata, Hash
+      end
 
       belongs_to :target, polymorphic: true
       belongs_to :object, polymorphic: true, optional: true

--- a/notification-settings/Gemfile.lock
+++ b/notification-settings/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    notification-settings (3.0.3)
+    notification-settings (4.0.1)
       activemodel (>= 5.0)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       hashie (>= 3.6, < 6.0)
-      notification-handler (= 3.0.3)
+      notification-handler (= 4.0.1)
       railties (>= 5.0)
 
 GEM
@@ -138,7 +138,7 @@ GEM
     nokogiri (1.16.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    notification-handler (3.0.3)
+    notification-handler (4.0.1)
       activerecord (>= 5.0)
       activesupport (>= 5.0)
       railties (>= 5.0)

--- a/notification-settings/lib/notification_settings/settings.rb
+++ b/notification-settings/lib/notification_settings/settings.rb
@@ -10,7 +10,11 @@ module NotificationSettings
     included do
       before_validation :build_settings
 
-      serialize :settings, Hashie::Mash
+      if ActiveRecord.gem_version >= Gem::Version.new('7.0.0')
+        serialize :settings, type: Hashie::Mash, coder: YAML
+      else
+        serialize :settings, Hashie::Mash
+      end
 
       include NotificationSettings::Settings::InstanceMethods
     end


### PR DESCRIPTION
[Address this issue](https://github.com/jonhue/notifications-rails/issues/2528)

ActiveRecord 7 introduced a change in the `serialize` method, requiring
the `coder:` keyword argument instead of the previous syntax. This commit
adds version detection to apply the correct `serialize` syntax dynamically.

This ensures the library remains compatible across different versions of
ActiveRecord without breaking older setups.